### PR TITLE
Fix PyPi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
       - run: poetry install
       - name: Build and publish
         run: |
-          poetry version $(git describe --tags --abbrev=0)
+          tag="$(git describe --tags --abbrev=0)"
+          if ! [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Unable to read version from ${tag}"
+            exit 1
+          fi
+          version="${tag:1}"
+          poetry version $version
           poetry build
           poetry publish --username "__token__" --password "${{secrets.PYPI_TOKEN}}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "json-mapper"
+name = "json-position-mapper"
 version = "0.0.0"
 description = "Map file-based JSON inputs from the file keys to their locations in the original file"
 authors = ["Adam Peacock <apeacock@atlantistech.com>", "Adam Peacock <adam@thepeacock.net>"]


### PR DESCRIPTION
Fix the configurations so that this can be properly published to PyPi

- Update the release tag reader so that the tag has to start with "v" for automated publishing to work
- Update the project name to the proper json-position-mapper